### PR TITLE
updates quay org name to saas-patterns

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: freshrss
-        image: quay.io/mhrivnak/freshrss:latest
+        image: quay.io/saas-patterns/freshrss:latest
         ports:
         - containerPort: 8080


### PR DESCRIPTION
The project moved from my personal github and quay orgs to a new
"saas-patterns" org in each service.